### PR TITLE
Added Output Enable pin to documentation

### DIFF
--- a/docs/RELAY_ESP32S3.MD
+++ b/docs/RELAY_ESP32S3.MD
@@ -86,9 +86,9 @@ Please enter the upload mode manually.
 
 ## 4️⃣ ESP32S3 Pins:
 
-| Shift register | DATA | CLOCK | LATCH |
-| -------------- | ---- | ----- | ----- |
-| GPIO           | 7    | 5     | 6     |
+| Shift register | DATA | CLOCK | LATCH | nOE |
+| -------------- | ---- | ----- | ----- | --- |
+| GPIO           | 7    | 5     | 6     | 4   |
 
 | RTC  | SDA | SCL | IRQ |
 | ---- | --- | --- | --- |


### PR DESCRIPTION
Was wondering why toggling an LED on IO4 also toggled the relays. Found the issue in the schematic. 